### PR TITLE
chore(deps): update dependency nock to v13.1.0 (#1975)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6696,9 +6696,9 @@
       }
     },
     "nock": {
-      "version": "13.0.11",
-      "resolved": "https://registry.npmjs.org/nock/-/nock-13.0.11.tgz",
-      "integrity": "sha512-sKZltNkkWblkqqPAsjYW0bm3s9DcHRPiMOyKO/PkfJ+ANHZ2+LA2PLe22r4lLrKgXaiSaDQwW3qGsJFtIpQIeQ==",
+      "version": "13.1.0",
+      "resolved": "https://registry.npmjs.org/nock/-/nock-13.1.0.tgz",
+      "integrity": "sha512-3N3DUY8XYrxxzWazQ+nSBpiaJ3q6gcpNh4gXovC/QBxrsvNp4tq+wsLHF6mJ3nrn3lPLn7KCJqKxy/9aD+0fdw==",
       "dev": true,
       "requires": {
         "debug": "^4.1.0",

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "got": "11.8.2",
     "js-yaml": "3.14.1",
     "mockserver-client": "5.11.2",
-    "nock": "13.0.11",
+    "nock": "13.1.0",
     "nyc": "15.1.0",
     "p-retry": "4.5.0",
     "proxyquire": "2.1.3",


### PR DESCRIPTION
Co-authored-by: Renovate Bot <bot@renovateapp.com>